### PR TITLE
Remove "flex" for Settings tabs

### DIFF
--- a/chrome/content/dendzones/settings.xul
+++ b/chrome/content/dendzones/settings.xul
@@ -37,8 +37,8 @@
         <vbox id="sourcelists" flex="1">
             <tabbox id="tabbox_sourcelists" flex="1">
                 <tabs>
-                    <tab label="&dendzones.settings.searchengines;" flex="1"/>
-                    <tab label="&dendzones.settings.cmitems;" flex="1"/>
+                    <tab label="&dendzones.settings.searchengines;"/>
+                    <tab label="&dendzones.settings.cmitems;"/>
                 </tabs>
                 <tabpanels flex="1">
                     <tabpanel>


### PR DESCRIPTION
This avoids extra blank on tabs.
![Screenshots](https://cloud.githubusercontent.com/assets/1769875/11955634/7e7e66c8-a8ee-11e5-87e6-07a33a552032.png)
