### PR TITLE
Possible solution for #9

### DIFF
--- a/chrome/content/dendzones/dendzones.js
+++ b/chrome/content/dendzones/dendzones.js
@@ -586,6 +586,15 @@ var DenDZonesShell =
         if (!DenDZonesShell.DenDZones_CheckDZHandlesThisDrop(oEvent))
         {
             DenDZonesShell.DenDZones_UpdateDropZones('destroy');
+
+            //Dropped outside of a dropzone, check if we should cancel the event
+            if (DenDZonesShell.oDenDZones_Utils.GetBool("cancelondropoutsidezone"))
+            {
+                oEvent.stopPropagation();
+                oEvent.preventDefault();
+
+                return;
+            }
         }
         var iResult = DenDZonesShell.DenDZones_HandleThisDenDOperation(oEvent, nsDragAndDrop.mDragSession, sDropData);
         if (iResult == 1 || iResult == 2 || iResult == 3)

--- a/chrome/content/dendzones/settings.xul
+++ b/chrome/content/dendzones/settings.xul
@@ -31,6 +31,7 @@
         <preference id="pref_openintab" name="extensions.dendzones.search.openintab" type="bool"/>
         <preference id="pref_activatetab" name="extensions.dendzones.search.activatetab" type="bool"/>
         <preference id="pref_handlecontextclick" name="extensions.dendzones.handlecontextclick" type="bool"/>
+        <preference id="pref_cancelondropoutsidezone" name="extensions.dendzones.cancelondropoutsidezone" type="bool"/>
     </preferences>
 
     <hbox flex="1">
@@ -115,6 +116,7 @@
                 <checkbox preference="pref_useforimages" label="&dendzones.settings.other.useforimages;"/>
                 <checkbox preference="pref_useforlinks" label="&dendzones.settings.other.useforlinks;"/>
                 <checkbox preference="pref_handlecontextclick" label="&dendzones.settings.other.handlecontextclick;"/>
+                <checkbox preference="pref_cancelondropoutsidezone" label="&dendzones.settings.other.cancelondropoutsidezone;"/>
             </groupbox>
         </vbox>
     </hbox>

--- a/chrome/locale/en-US/dendzones.dtd
+++ b/chrome/locale/en-US/dendzones.dtd
@@ -18,3 +18,4 @@
 <!ENTITY dendzones.settings.search.openintab "Open search results in a new tab">
 <!ENTITY dendzones.settings.search.activatetab "Activate a new tab opened from a search">
 <!ENTITY dendzones.settings.other.handlecontextclick "Use Drag &amp; DropZones instead of the context menu">
+<!ENTITY dendzones.settings.other.cancelondropoutsidezone "Cancel drop when dropping on empty zones">

--- a/chrome/locale/nl/dendzones.dtd
+++ b/chrome/locale/nl/dendzones.dtd
@@ -18,3 +18,4 @@
 <!ENTITY dendzones.settings.search.openintab "Zoekresultaten in een nieuw tabblad openen">
 <!ENTITY dendzones.settings.search.activatetab "Een nieuw tabblad geopend vanuit een zoekopdracht activeren">
 <!ENTITY dendzones.settings.other.handlecontextclick "Drag &amp; DropZones gebruiken in plaats van het contextmenu">
+<!ENTITY dendzones.settings.other.cancelondropoutsidezone "Annuleer de actie bij het slepen naar een lege dropzone">

--- a/defaults/preferences/prefs.js
+++ b/defaults/preferences/prefs.js
@@ -15,3 +15,4 @@ pref("extensions.dendzones.handlecontextclick", false);
 pref("extensions.dendzones.maxaxis", 0);
 pref("extensions.dendzones.activateonctrlshiftclick", true);
 pref("extensions.dendzones.version", "");
+pref("extensions.dendzones.cancelondropoutsidezone", false);


### PR DESCRIPTION
If the drop occurs outside any of the drop zones the default action is to let the event bubble up for other extensions or Firefox itself to handle.
By stopping the event we can prevent this. And in style with the rest of the extension we made this behaviour optional, false by default to prevent a change for existing users.

You decide now Andy, thanks for the great work you are doing to continue my wok!

Cheers.
Martijn

Edit: Still new to GitHub... Should have made the pull request for issue #9, not sure how to change afterwards...
